### PR TITLE
[FEAT]: 게시글 스크랩 API 구현

### DIFF
--- a/src/main/java/mvp/deplog/domain/post/domain/Post.java
+++ b/src/main/java/mvp/deplog/domain/post/domain/Post.java
@@ -63,4 +63,10 @@ public class Post extends BaseEntity {
         this.viewCount = 0;
         this.stage = stage;
     }
+
+
+    // 스크랩 수 증가
+    public void incrementScrapCount() {
+        this.scrapCount++;
+    }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
+++ b/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
@@ -1,0 +1,14 @@
+package mvp.deplog.domain.scrap.application;
+
+import lombok.RequiredArgsConstructor;
+import mvp.deplog.domain.scrap.domain.repository.ScrapRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ScrapService {
+
+    private final ScrapRepository scrapRepository;
+}

--- a/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
+++ b/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
@@ -1,7 +1,14 @@
 package mvp.deplog.domain.scrap.application;
 
 import lombok.RequiredArgsConstructor;
+import mvp.deplog.domain.member.domain.Member;
+import mvp.deplog.domain.member.domain.repository.MemberRepository;
+import mvp.deplog.domain.post.domain.Post;
+import mvp.deplog.domain.post.domain.repository.PostRepository;
+import mvp.deplog.domain.scrap.domain.Scrap;
 import mvp.deplog.domain.scrap.domain.repository.ScrapRepository;
+import mvp.deplog.global.common.Message;
+import mvp.deplog.global.common.SuccessResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,4 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScrapService {
 
     private final ScrapRepository scrapRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public SuccessResponse<Message> scrapPost(Member member, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 게시글이 없습니다: " + postId));
+
+        Scrap scrap = Scrap.builder()
+                .post(post)
+                .member(member)
+                .build();
+
+        post.incrementScrapCount();
+        postRepository.save(post);      // 스크랩 수 저장
+        scrapRepository.save(scrap);    // 스크랩 저장
+
+        Message message = Message.builder()
+                .message("게시글 스크랩을 완료했습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
+++ b/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
@@ -19,11 +19,17 @@ public class ScrapService {
 
     private final ScrapRepository scrapRepository;
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
-    public SuccessResponse<Message> scrapPost(Member member, Long postId) {
+    public SuccessResponse<Message> scrapPost(Long memberId, Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 게시글이 없습니다: " + postId));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원이 없습니다: " + memberId));
+        if(scrapRepository.existsByMemberAndPost(member, post)){
+            throw new IllegalArgumentException("이미 스크랩된 게시글입니다.");
+        }
 
         Scrap scrap = Scrap.builder()
                 .post(post)
@@ -31,7 +37,6 @@ public class ScrapService {
                 .build();
 
         post.incrementScrapCount();
-        postRepository.save(post);      // 스크랩 수 저장
         scrapRepository.save(scrap);    // 스크랩 저장
 
         Message message = Message.builder()

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -1,0 +1,7 @@
+package mvp.deplog.domain.scrap.domain.repository;
+
+import mvp.deplog.domain.scrap.domain.Scrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+}

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -4,4 +4,5 @@ import mvp.deplog.domain.scrap.domain.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
 }

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -1,8 +1,11 @@
 package mvp.deplog.domain.scrap.domain.repository;
 
+import mvp.deplog.domain.member.domain.Member;
+import mvp.deplog.domain.post.domain.Post;
 import mvp.deplog.domain.scrap.domain.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
+    boolean existsByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
@@ -1,9 +1,21 @@
 package mvp.deplog.domain.scrap.presentation;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import mvp.deplog.global.common.Message;
+import mvp.deplog.global.common.SuccessResponse;
+import mvp.deplog.global.security.UserDetailsImpl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Scrap API", description = "스크랩 관련 API 입니다.")
 public interface ScrapApi {
 
-
+    @PostMapping("/{post_id}")
+    ResponseEntity<SuccessResponse<Message>> scrapPost(
+            @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "Schemas의 ScrapReq를 참고해주세요.", required = true) @PathVariable(value = "post_id")Long postId
+            );
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
@@ -1,9 +1,16 @@
 package mvp.deplog.domain.scrap.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import mvp.deplog.domain.comment.dto.response.CommentRes;
 import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.SuccessResponse;
+import mvp.deplog.global.exception.ErrorResponse;
 import mvp.deplog.global.security.UserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +20,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Tag(name = "Scrap API", description = "스크랩 관련 API 입니다.")
 public interface ScrapApi {
 
+    @Operation(summary = "스크랩 API", description = "게시글을 스크랩합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201", description = "스크랩 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "스크랩 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
     @PostMapping("/{post_id}")
     ResponseEntity<SuccessResponse<Message>> scrapPost(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
@@ -1,0 +1,9 @@
+package mvp.deplog.domain.scrap.presentation;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Scrap API", description = "스크랩 관련 API 입니다.")
+public interface ScrapApi {
+
+
+}

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
@@ -1,0 +1,14 @@
+package mvp.deplog.domain.scrap.presentation;
+
+import lombok.RequiredArgsConstructor;
+import mvp.deplog.domain.scrap.application.ScrapService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/scrap")
+public class ScrapController implements ScrapApi {
+
+    private final ScrapService scrapService;
+}

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
@@ -1,7 +1,18 @@
 package mvp.deplog.domain.scrap.presentation;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import mvp.deplog.domain.post.domain.repository.PostRepository;
+import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.domain.scrap.application.ScrapService;
+import mvp.deplog.global.common.Message;
+import mvp.deplog.global.common.SuccessResponse;
+import mvp.deplog.global.security.UserDetailsImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +22,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScrapController implements ScrapApi {
 
     private final ScrapService scrapService;
+
+    @Override
+    @PostMapping("/{post_id}")
+    public ResponseEntity<SuccessResponse<Message>> scrapPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                              @PathVariable(value = "post_id") Long postId){
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(scrapService.scrapPost(userDetails.getMember(), postId));
+    }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/scrap")
+@RequestMapping("/scraps")
 public class ScrapController implements ScrapApi {
 
     private final ScrapService scrapService;
@@ -29,6 +29,6 @@ public class ScrapController implements ScrapApi {
                                                               @PathVariable(value = "post_id") Long postId){
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(scrapService.scrapPost(userDetails.getMember(), postId));
+                .body(scrapService.scrapPost(userDetails.getMember().getId(), postId));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 게시글 스크랩 api 구현

### 📷 스크린샷

화면 설계서 내 구현 내용
![스크린샷 2024-08-08 134133](https://github.com/user-attachments/assets/15a0a64f-a5d6-411c-bf06-395844fd5524)


스크랩 요청 api 테스트
![스크린샷 2024-08-08 035301](https://github.com/user-attachments/assets/065d511b-4336-4a4a-ac1d-8050b1f345d4)

scrapCount가 0->1로 증가함 확인
![스크린샷 2024-08-08 035327](https://github.com/user-attachments/assets/edbbce76-318d-41c5-b280-99884b85aa25)

없는 게시글 요청 시 뜨는 에러 코드
![스크린샷 2024-08-08 035356](https://github.com/user-attachments/assets/4a655b3b-3305-4bfa-afe3-cf1363e0b2ac)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #36 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

게시글 상세 조회를 위해 게시글 스크랩 기능 먼저 구현했습니다.
스크랩 수 증가를 위해 Post Entity에 메서드 추가했습니다.
pr이 승인되면 위 기능 참고하여 좋아요 기능까지 빠르게 완료하겠습니다.