### PR TITLE
[FEAT]: 게시글 스크랩 해제 API 구현

### DIFF
--- a/src/main/java/mvp/deplog/domain/post/domain/Post.java
+++ b/src/main/java/mvp/deplog/domain/post/domain/Post.java
@@ -69,4 +69,10 @@ public class Post extends BaseEntity {
     public void incrementScrapCount() {
         this.scrapCount++;
     }
+    // 스크랩 수 감소
+    public void decrementScrapCount() {
+        if(this.scrapCount > 0){
+            this.scrapCount--;
+        }
+    }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
+++ b/src/main/java/mvp/deplog/domain/scrap/application/ScrapService.java
@@ -45,4 +45,23 @@ public class ScrapService {
 
         return SuccessResponse.of(message);
     }
+
+    @Transactional
+    public SuccessResponse<Message> deleteScrapPost(Long memberId, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 게시글이 없습니다: " + postId));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원이 없습니다: " + memberId));
+        Scrap scrap = scrapRepository.findByMemberAndPost(member, post)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글은 스크랩하지 않았습니다. 먼저 스크랩해주세요."));
+
+        post.decrementScrapCount();
+        scrapRepository.delete(scrap);
+
+        Message message = Message.builder()
+                .message("게시글 스크랩 해제를 완료했습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
+    }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -12,5 +12,4 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     boolean existsByMemberAndPost(Member member, Post post);
 
     Optional<Scrap> findByMemberAndPost(Member member, Post post);
-
 }

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -12,4 +12,5 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     boolean existsByMemberAndPost(Member member, Post post);
 
     Optional<Scrap> findByMemberAndPost(Member member, Post post);
+
 }

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -5,7 +5,11 @@ import mvp.deplog.domain.post.domain.Post;
 import mvp.deplog.domain.scrap.domain.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     boolean existsByMemberAndPost(Member member, Post post);
+
+    Optional<Scrap> findByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
@@ -32,10 +32,10 @@ public interface ScrapApi {
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
             )
     })
-    @PostMapping("/{post_id}")
+    @PostMapping("/{postId}")
     ResponseEntity<SuccessResponse<Message>> scrapPost(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Parameter(description = "스크랩 할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "post_id")Long postId
+            @Parameter(description = "스크랩 할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "postId")Long postId
             );
 
     @Operation(summary = "스크랩 해제 API", description = "스크랩한 게시글을 해제합니다.")
@@ -49,9 +49,9 @@ public interface ScrapApi {
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
             )
     })
-    @DeleteMapping("/{post_id}")
+    @DeleteMapping("/{postId}")
     ResponseEntity<SuccessResponse<Message>> deleteScrapPost(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Parameter(description = "스크랩을 해제할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "post_id")Long postId
+            @Parameter(description = "스크랩을 해제할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "postId")Long postId
             );
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
@@ -38,6 +38,17 @@ public interface ScrapApi {
             @Parameter(description = "스크랩 할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "post_id")Long postId
             );
 
+    @Operation(summary = "스크랩 해제 API", description = "스크랩한 게시글을 해제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "스크랩 해제 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "스크랩 해제 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
     @DeleteMapping("/{post_id}")
     ResponseEntity<SuccessResponse<Message>> deleteScrapPost(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapApi.java
@@ -14,6 +14,7 @@ import mvp.deplog.global.exception.ErrorResponse;
 import mvp.deplog.global.security.UserDetailsImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -34,6 +35,12 @@ public interface ScrapApi {
     @PostMapping("/{post_id}")
     ResponseEntity<SuccessResponse<Message>> scrapPost(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Parameter(description = "Schemas의 ScrapReq를 참고해주세요.", required = true) @PathVariable(value = "post_id")Long postId
+            @Parameter(description = "스크랩 할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "post_id")Long postId
+            );
+
+    @DeleteMapping("/{post_id}")
+    ResponseEntity<SuccessResponse<Message>> deleteScrapPost(
+            @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "스크랩을 해제할 게시글의 id를 입력해주세요.", required = true) @PathVariable(value = "post_id")Long postId
             );
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
@@ -1,9 +1,6 @@
 package mvp.deplog.domain.scrap.presentation;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import mvp.deplog.domain.post.domain.repository.PostRepository;
-import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.domain.scrap.application.ScrapService;
 import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.SuccessResponse;
@@ -11,10 +8,7 @@ import mvp.deplog.global.security.UserDetailsImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -30,5 +24,14 @@ public class ScrapController implements ScrapApi {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(scrapService.scrapPost(userDetails.getMember().getId(), postId));
+    }
+
+    @Override
+    @DeleteMapping("/{post_id}")
+    public ResponseEntity<SuccessResponse<Message>> deleteScrapPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                    @PathVariable(value = "post_id") Long postId){
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(scrapService.deleteScrapPost(userDetails.getMember().getId(), postId));
     }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
@@ -30,8 +30,6 @@ public class ScrapController implements ScrapApi {
     @DeleteMapping("/{post_id}")
     public ResponseEntity<SuccessResponse<Message>> deleteScrapPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                     @PathVariable(value = "post_id") Long postId){
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(scrapService.deleteScrapPost(userDetails.getMember().getId(), postId));
+        return ResponseEntity.ok(scrapService.deleteScrapPost(userDetails.getMember().getId(), postId));
     }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
+++ b/src/main/java/mvp/deplog/domain/scrap/presentation/ScrapController.java
@@ -18,18 +18,18 @@ public class ScrapController implements ScrapApi {
     private final ScrapService scrapService;
 
     @Override
-    @PostMapping("/{post_id}")
+    @PostMapping("/{postId}")
     public ResponseEntity<SuccessResponse<Message>> scrapPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                              @PathVariable(value = "post_id") Long postId){
+                                                              @PathVariable(value = "postId") Long postId){
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(scrapService.scrapPost(userDetails.getMember().getId(), postId));
     }
 
     @Override
-    @DeleteMapping("/{post_id}")
+    @DeleteMapping("/{postId}")
     public ResponseEntity<SuccessResponse<Message>> deleteScrapPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                    @PathVariable(value = "post_id") Long postId){
+                                                                    @PathVariable(value = "postId") Long postId){
         return ResponseEntity.ok(scrapService.deleteScrapPost(userDetails.getMember().getId(), postId));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 게시글 스크랩 해제 api

### 📷 스크린샷

화면설계서 내 구현 기능
![스크린샷 2024-08-08 134133](https://github.com/user-attachments/assets/30cd183d-036c-4435-bf33-aebe95eab28e)

postman 테스트 결과
성공 시
![스크린샷 2024-08-08 153612](https://github.com/user-attachments/assets/7eb61ebd-505d-4baa-a98a-23182128325e)
실패 시
![스크린샷 2024-08-08 153622](https://github.com/user-attachments/assets/0782b87f-90cb-4340-a60c-0120ba83c011)

DB 변화
스크랩 해제 api 전송 전
scrap Entity
![스크린샷 2024-08-08 153536](https://github.com/user-attachments/assets/087db63d-e5d2-428f-bb36-852f5154c065)

스크랩 해제 api 전송 후
post Entity
![스크린샷 2024-08-08 153702](https://github.com/user-attachments/assets/2ebde9ea-176c-410a-a41c-d141bf3e9fb2)
scrap Entity
![스크린샷 2024-08-08 153708](https://github.com/user-attachments/assets/fb99773d-cec8-4311-9aff-bc6115f99afb)



## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #40 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

스크랩 해제 api 구현했습니다. 이전 스크랩 api pr 내용 참고하여 작성했습니다.
만약 pr된다면 좋아요 기능 구현 시 좋아요 추가 및 삭제 api를 하나의 이슈로 묶어서 개발해도 괜찮은 지 여쭤봅니다.

스크랩 api에 대한 swagger 설정도 변경했습니다.