### PR TITLE
[FEAT]: 게시글 삭제 API 구현

### DIFF
--- a/src/main/java/mvp/deplog/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/mvp/deplog/domain/comment/domain/repository/CommentRepository.java
@@ -10,5 +10,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByPost(Post post);
 
-    List<Comment> findByParentComment(Comment parentComment);
+    void deleteByPost(Post post);
 }

--- a/src/main/java/mvp/deplog/domain/likes/domain/repository/LikesRepository.java
+++ b/src/main/java/mvp/deplog/domain/likes/domain/repository/LikesRepository.java
@@ -12,4 +12,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     boolean existsByMemberAndPost(Member member, Post post);
 
     Optional<Likes> findByMemberAndPost(Member member, Post post);
+
+    void deleteByPost(Post post);
 }

--- a/src/main/java/mvp/deplog/domain/post/application/PostService.java
+++ b/src/main/java/mvp/deplog/domain/post/application/PostService.java
@@ -1,6 +1,7 @@
 package mvp.deplog.domain.post.application;
 
 import lombok.RequiredArgsConstructor;
+import mvp.deplog.domain.comment.domain.repository.CommentRepository;
 import mvp.deplog.domain.likes.domain.repository.LikesRepository;
 import mvp.deplog.domain.member.domain.Member;
 import mvp.deplog.domain.member.domain.Part;
@@ -13,11 +14,13 @@ import mvp.deplog.domain.post.dto.request.CreatePostReq;
 import mvp.deplog.domain.post.dto.response.PostDetailsRes;
 import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.domain.post.exception.ResourceNotFoundException;
+import mvp.deplog.domain.post.exception.UnauthorizedException;
 import mvp.deplog.domain.scrap.domain.repository.ScrapRepository;
 import mvp.deplog.domain.tag.domain.Tag;
 import mvp.deplog.domain.tag.domain.repository.TagRepository;
 import mvp.deplog.domain.tagging.Tagging;
 import mvp.deplog.domain.tagging.repository.TaggingRepository;
+import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.PageInfo;
 import mvp.deplog.global.common.PageResponse;
 import mvp.deplog.global.common.SuccessResponse;
@@ -50,6 +53,7 @@ public class PostService {
 
     private static final String DIRNAME = "post";
     private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public SuccessResponse<CreatePostRes> createPost(Member member, CreatePostReq createPostReq) {
@@ -251,5 +255,38 @@ public class PostService {
         PageResponse pageResponse = PageResponse.toPageResponse(pageInfo, searchPostList.getContent());
 
         return SuccessResponse.of(pageResponse);
+    }
+
+    @Transactional
+    public SuccessResponse<Message> deletePost(Long memberId, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 id의 게시글을 찾을 수 없습니다: " + postId));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 멤버를 찾을 수 없습니다: " + memberId));
+
+        if(!post.getMember().equals(member)) {
+            throw new UnauthorizedException("본인이 작성한 게시글이 아니므로 삭제할 수 없습니다.");
+        }
+
+        // 게시글 내 댓글 삭제
+        commentRepository.deleteByPost(post);
+
+        // 게시글 내 태그 삭제
+        taggingRepository.deleteByPost(post);
+
+        // 게시글 스크랩 내용 삭제
+        scrapRepository.deleteByPost(post);
+
+        // 게시글 좋아요 내용 삭제
+        likesRepository.deleteByPost(post);
+
+        // 게시글 삭제
+        postRepository.delete(post);
+
+        Message message = Message.builder()
+                .message("게시글 삭제가 완료되었습니다.")
+                .build();
+
+        return SuccessResponse.of(message);
     }
 }

--- a/src/main/java/mvp/deplog/domain/post/application/PostService.java
+++ b/src/main/java/mvp/deplog/domain/post/application/PostService.java
@@ -228,7 +228,7 @@ public class PostService {
     public SuccessResponse<PageResponse> getSearchPostsByTag(String tagName, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
         Tag tag = tagRepository.findByName(tagName)
-                .orElseThrow(() -> new IllegalArgumentException("해당 이름의 태그가 없습니다" + tagName));
+                .orElseThrow(() -> new IllegalArgumentException("해당 이름의 태그가 없습니다: " + tagName));
 
         Page<Tagging> taggingPosts = taggingRepository.findByTag(tag, pageable);
 

--- a/src/main/java/mvp/deplog/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/mvp/deplog/domain/post/domain/repository/PostRepository.java
@@ -1,6 +1,5 @@
 package mvp.deplog.domain.post.domain.repository;
 
-import mvp.deplog.domain.member.domain.Member;
 import mvp.deplog.domain.member.domain.Part;
 import mvp.deplog.domain.post.domain.Post;
 import org.springframework.data.domain.Page;
@@ -17,6 +16,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByMemberPart(@Param("parts") List<Part> partGroup, Pageable pageable);
 
     Page<Post> findByTitleContainingOrContentContaining(String titleSearchWord, String contentSearchWord, Pageable pageable);
-
-    Post findByMember(Member member);
 }

--- a/src/main/java/mvp/deplog/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/mvp/deplog/domain/post/domain/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package mvp.deplog.domain.post.domain.repository;
 
+import mvp.deplog.domain.member.domain.Member;
 import mvp.deplog.domain.member.domain.Part;
 import mvp.deplog.domain.post.domain.Post;
 import org.springframework.data.domain.Page;
@@ -16,4 +17,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByMemberPart(@Param("parts") List<Part> partGroup, Pageable pageable);
 
     Page<Post> findByTitleContainingOrContentContaining(String titleSearchWord, String contentSearchWord, Pageable pageable);
+
+    Post findByMember(Member member);
 }

--- a/src/main/java/mvp/deplog/domain/post/exception/UnauthorizedException.java
+++ b/src/main/java/mvp/deplog/domain/post/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package mvp.deplog.domain.post.exception;
+
+public class UnauthorizedException extends RuntimeException{
+
+    public UnauthorizedException(String msg) { super(msg); }
+}
+

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -164,6 +164,17 @@ public interface PostApi {
             @Parameter(description = "한 페이지 당 최대 항목 개수를 입력해주세요. 기본값은 10입니다.", required = true) @RequestParam(value = "size", defaultValue = "10") Integer size
     );
 
+    @Operation(summary = "게시글 삭제 API", description = "해당 아이디의 게시글을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "게시글 삭제 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "게시글 삭제 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
     @DeleteMapping("/{postId}")
     ResponseEntity<SuccessResponse<Message>> deletePost(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -163,4 +163,10 @@ public interface PostApi {
             @Parameter(description = "조회할 페이지의 번호를 입력해주세요. **page는 1부터 시작합니다**", required = true) @RequestParam(value = "page", defaultValue = "1") Integer page,
             @Parameter(description = "한 페이지 당 최대 항목 개수를 입력해주세요. 기본값은 10입니다.", required = true) @RequestParam(value = "size", defaultValue = "10") Integer size
     );
+
+    @DeleteMapping("/{postId}")
+    ResponseEntity<SuccessResponse<Message>> deletePost(
+            @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "삭제할 게시글의 아이디를 입력하세요.", required = true) @PathVariable(value = "postId") Long postId
+    );
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
@@ -77,7 +77,7 @@ public class PostController implements PostApi {
     }
 
     @Override
-    @DeleteMapping("{postId}")
+    @DeleteMapping("/{postId}")
     public ResponseEntity<SuccessResponse<Message>> deletePost(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                @PathVariable(value = "postId") Long postId) {
         return ResponseEntity.ok(postService.deletePost(userDetails.getMember().getId(), postId));

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
@@ -6,6 +6,7 @@ import mvp.deplog.domain.post.application.PostService;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
 import mvp.deplog.domain.post.dto.response.PostDetailsRes;
+import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.PageResponse;
 import mvp.deplog.global.common.SuccessResponse;
 import mvp.deplog.global.security.UserDetailsImpl;
@@ -73,5 +74,12 @@ public class PostController implements PostApi {
                                                                                  @RequestParam(defaultValue = "1") Integer page,
                                                                                  @RequestParam(defaultValue = "10") Integer size) {
         return ResponseEntity.ok(postService.getSearchPostsByTag(tagName, page-1, size));
+    }
+
+    @Override
+    @DeleteMapping("{postId}")
+    public ResponseEntity<SuccessResponse<Message>> deletePost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                               @PathVariable(value = "postId") Long postId) {
+        return ResponseEntity.ok(postService.deletePost(userDetails.getMember().getId(), postId));
     }
 }

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {

--- a/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
+++ b/src/main/java/mvp/deplog/domain/scrap/domain/repository/ScrapRepository.java
@@ -17,4 +17,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     Optional<Scrap> findByMemberAndPost(Member member, Post post);
 
     Page<Scrap> findByMember(Member member, Pageable pageable);
+
+    void deleteByPost(Post post);
 }

--- a/src/main/java/mvp/deplog/domain/tagging/repository/TaggingRepository.java
+++ b/src/main/java/mvp/deplog/domain/tagging/repository/TaggingRepository.java
@@ -12,5 +12,8 @@ import java.util.List;
 public interface TaggingRepository extends JpaRepository<Tagging, Long> {
 
     List<Tagging> findByPost(Post post);
+
     Page<Tagging> findByTag(Tag tag, Pageable pageable);
+
+    void deleteByPost(Post post);
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 게시글 삭제 api 구현

### 📷 스크린샷
화면 설계서 상 구현 내용
![스크린샷 2024-08-12 001103](https://github.com/user-attachments/assets/9291b716-ff4e-4ae1-94e1-03a406768700)

포스트맨 테스트 결과
게시글 삭제 성공
![삭제 완료](https://github.com/user-attachments/assets/11fbbe38-6d93-494c-a01f-51374e350c32)

게시글 삭제 실패 1. 삭제할 게시글이 없는 게시글인 경우
![해당 게시글이 없을 시](https://github.com/user-attachments/assets/bf40fb7a-4d67-41dd-bea9-2db02e2091b3)

게시글 삭제 실패 2. 게시글이 본인이 작성한 게시글이 아닌 경우
![본인 작성 게시글이 아닐 시](https://github.com/user-attachments/assets/d293b3cc-188d-488c-a2a5-20dfb72940de)

각 DB의 변화
1. 게시글 테이블(Post)
삭제 전
![post 테이블](https://github.com/user-attachments/assets/8e5e9fda-634b-4aa1-b9bd-5346e5205466)

삭제 후
![삭제 후 post 테이블](https://github.com/user-attachments/assets/675ed55e-14c4-428c-bf6b-8da8a843345a)

2. 태깅 테이블(Tagging) - 게시글과 태그의 연관관계를 나타냄
삭제 전
![tagging 테이블](https://github.com/user-attachments/assets/835170b7-dc33-445b-9dbe-6b31f2ed401c)

삭제 후
![삭제 후 tagging 테이블](https://github.com/user-attachments/assets/553f63ac-7d31-4b44-b043-30a612d9ea46)

3. 댓글 테이블(Comment) - 댓글과 대댓글 모두 한번에 삭제됨을 확인
삭제 전
![comment 테이블](https://github.com/user-attachments/assets/0bf370c6-2b24-41ef-8e14-3143805dbd10)

삭제 후
![삭제 후 comment 테이블](https://github.com/user-attachments/assets/9e280b23-c57b-4a01-bc4e-ca713de73199)

4. 스크랩 및 좋아요 테이블(Scrap, Likes) - 누른 순서에 상관 없이 전부 삭제
삭제 전
Scrap
![scrap 테이블](https://github.com/user-attachments/assets/b79e7156-6f3d-4d1e-be7c-2c08a2960d4c)
Likes
![likes 테이블](https://github.com/user-attachments/assets/f80417b3-8a67-4ca6-8673-b486b5f20af8)

삭제 후
Scrap
![삭제 후 scrap 테이블](https://github.com/user-attachments/assets/cc69694a-e460-44c1-ae68-5a02ca7877dc)
Likes
![삭제 후 likes 테이블](https://github.com/user-attachments/assets/7ccd291b-6353-4b63-b5f7-66249020c79d)

5. 태그 테이블(Tag) - 삭제에도 불구하고 Tag 테이블은 변화가 없음을 확인
삭제 후
![tag 테이블](https://github.com/user-attachments/assets/dd248276-142e-46eb-85b1-cdcf411c8abe)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #56 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

게시글 삭제 API 구현 완료했습니다.
게시글이 삭제되기 전에 게시글과 연관되어 있는 모든 요소(태그 연관관계, 댓글, 스크랩, 좋아요)를 선 삭제하도록 구현했습니다.
추후에 기회가 된다면 게시글 삭제 후 Tag중 연관되어 있는 게시글이 없다면 Tag를 삭제하거나 비활 처리하는 기능을 추가하고 싶습니다.