### PR TITLE
[FEAT}: 임시 저장 게시글 API 구현

### DIFF
--- a/src/main/java/mvp/deplog/domain/post/application/PostService.java
+++ b/src/main/java/mvp/deplog/domain/post/application/PostService.java
@@ -304,8 +304,6 @@ public class PostService {
 
     @Transactional
     public SuccessResponse<CreatePostRes> createDraftPost(Member member, CreatePostReq createPostReq) {
-        validateTagName(createPostReq.getTagNameList());
-
         String content = createPostReq.getContent();
         String previewContent = MarkdownUtil.extractPreviewContent(content);
         String previewImage = MarkdownUtil.extractPreviewImage(content);
@@ -319,8 +317,9 @@ public class PostService {
                 .stage(Stage.TEMP)
                 .build();
 
-        // 게시글 저장
         Post savePost = postRepository.save(post);
+
+        taggingRepository.deleteByPost(post);
 
         // 태그 저장 & Tagging 엔티티 연결
         for(String tagName : createPostReq.getTagNameList()) {
@@ -332,11 +331,53 @@ public class PostService {
                     .post(post)
                     .tag(tag)
                     .build();
+
             taggingRepository.save(tagging);
         }
 
         CreatePostRes createPostRes = CreatePostRes.builder()
                 .postId(savePost.getId())
+                .build();
+
+        return SuccessResponse.of(createPostRes);
+    }
+
+    @Transactional
+    public SuccessResponse<CreatePostRes> publishDraftPost(Long memberId, Long postId, CreatePostReq createPostReq) {
+        validateTagName(createPostReq.getTagNameList());
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 id의 게시글을 찾을 수 없습니다: " + postId));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 멤버를 찾을 수 없습니다: " + memberId));
+
+        if(!post.getMember().equals(member)) {
+            throw new UnauthorizedException("본인이 작성한 게시글이 아니므로 발행할 수 없습니다.");
+        }
+
+        String content = createPostReq.getContent();
+        String previewContent = MarkdownUtil.extractPreviewContent(content);
+        String previewImage = MarkdownUtil.extractPreviewImage(content);
+
+        post.updatePost(createPostReq.getTitle(), content, previewContent, previewImage, Stage.PUBLISHED);
+
+        taggingRepository.deleteByPost(post);
+
+        // 태그 저장 & Tagging 엔티티 연결
+        for(String tagName : createPostReq.getTagNameList()) {
+            Tag tag = tagRepository.findByName(tagName)
+                    .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+
+            Tagging tagging = Tagging.builder()
+                    .post(post)
+                    .tag(tag)
+                    .build();
+
+            taggingRepository.save(tagging);
+        }
+
+        CreatePostRes createPostRes = CreatePostRes.builder()
+                .postId(postId)
                 .build();
 
         return SuccessResponse.of(createPostRes);

--- a/src/main/java/mvp/deplog/domain/post/domain/Post.java
+++ b/src/main/java/mvp/deplog/domain/post/domain/Post.java
@@ -64,6 +64,14 @@ public class Post extends BaseEntity {
         this.stage = stage;
     }
 
+    // 게시글 수정
+    public void updatePost(String title, String content, String previewContent, String previewImage, Stage stage) {
+        this.title = title;
+        this.content = content;
+        this.previewContent = previewContent;
+        this.previewImage = previewImage;
+        this.stage = stage;
+    }
 
     // 스크랩 수 증가
     public void incrementScrapCount() {

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -181,12 +181,34 @@ public interface PostApi {
             @Parameter(description = "삭제할 게시글의 아이디를 입력하세요.", required = true) @PathVariable(value = "postId") Long postId
     );
 
+    @Operation(summary = "게시글 임시 저장 API", description = "해당 아이디의 게시글을 임시 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201", description = "게시글 임시 저장 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CreatePostRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "게시글 임시 저장 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
     @PostMapping("/drafts")
     ResponseEntity<SuccessResponse<CreatePostRes>> createDraftPost(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
     );
 
+    @Operation(summary = "임시 저장 게시글 발행 API", description = "해당 아이디의 임시 저장 게시글을 벌행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "임시 저장 게시글 발행 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CreatePostRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "임시 저장 게시글 발행 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
     @PutMapping("/publishing")
     ResponseEntity<SuccessResponse<CreatePostRes>> publishDraftPost(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -186,4 +186,11 @@ public interface PostApi {
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
     );
+
+    @PutMapping("/publishing")
+    ResponseEntity<SuccessResponse<CreatePostRes>> publishDraftPost(
+            @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "발행할 임시 저장 게시글의 아이디를 입력하세요.", required = true) @RequestParam(value = "postId") Long postId,
+            @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
+    );
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -41,7 +41,7 @@ public interface PostApi {
     @PostMapping
     ResponseEntity<SuccessResponse<CreatePostRes>> createPost(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Parameter(description = "Schemas의 PostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
+            @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
     );
 
     @Operation(summary = "게시글 전체 목록 조회 API", description = "게시글 전체 목록을 출력합니다.")
@@ -179,5 +179,11 @@ public interface PostApi {
     ResponseEntity<SuccessResponse<Message>> deletePost(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "삭제할 게시글의 아이디를 입력하세요.", required = true) @PathVariable(value = "postId") Long postId
+    );
+
+    @PostMapping("/drafts")
+    ResponseEntity<SuccessResponse<CreatePostRes>> createDraftPost(
+            @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
     );
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
@@ -91,4 +91,12 @@ public class PostController implements PostApi {
                 .status(HttpStatus.CREATED)
                 .body(postService.createDraftPost(userDetails.getMember(), createPostReq));
     }
+
+    @Override
+    @PutMapping("/publishing")
+    public ResponseEntity<SuccessResponse<CreatePostRes>> publishDraftPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                           @RequestParam(value = "postId") Long postId,
+                                                                           @RequestBody CreatePostReq createPostReq) {
+        return ResponseEntity.ok(postService.publishDraftPost(userDetails.getMember().getId(), postId, createPostReq));
+    }
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
@@ -82,4 +82,13 @@ public class PostController implements PostApi {
                                                                @PathVariable(value = "postId") Long postId) {
         return ResponseEntity.ok(postService.deletePost(userDetails.getMember().getId(), postId));
     }
+
+    @Override
+    @PostMapping("/drafts")
+    public ResponseEntity<SuccessResponse<CreatePostRes>> createDraftPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @RequestBody CreatePostReq createPostReq) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(postService.createDraftPost(userDetails.getMember(), createPostReq));
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 임시 저장 게시글 작성 API
- [x] 임시 저장 게시글 발행 API

### 📷 스크린샷
화면 설계서 내 구현 내용
![스크린샷 2024-08-12 053711](https://github.com/user-attachments/assets/f9f59faa-f1d0-44ae-b01f-fec4c277177e)

포스트맨 테스트 결과
임시 저장 성공
![스크린샷 2024-08-12 054302](https://github.com/user-attachments/assets/1a5806ec-94f2-4b32-a080-e117ea2e86f9)
태그명이 겹칠 때도 성공하는지 테스트
![스크린샷 2024-08-12 054331](https://github.com/user-attachments/assets/c41355dc-2ec9-4708-a508-711c8b3c66c0)
Post 테이블 확인
![스크린샷 2024-08-12 054343](https://github.com/user-attachments/assets/912a4d68-54b9-43cb-8b34-e1b3d8ae576f)
Tagging 테이블 확인
![스크린샷 2024-08-12 054417](https://github.com/user-attachments/assets/c77d5f0c-83e5-47ac-b8b4-3cb1be7a9dd6)

임시 저장 게시글 발행
성공
![스크린샷 2024-08-12 054433](https://github.com/user-attachments/assets/d56b270d-fc33-4c51-9045-f178ea483e87)
중복되는 태그명이 있을 시 실패
![스크린샷 2024-08-12 054447](https://github.com/user-attachments/assets/d53020f1-c8b8-4f2c-9a4d-ed1148bc46de)
Post 테이블의 변화 확인 - 4번 게시글의 Stage가 TEMP → PUBLISHED로 변함
![스크린샷 2024-08-12 054513](https://github.com/user-attachments/assets/83fe4420-5fe7-4441-a052-6fb0ae6dfaea)
Tagging 테이블의 변화 확인
![스크린샷 2024-08-12 054505](https://github.com/user-attachments/assets/de3d218e-8d2f-44e0-b859-ab06f5d9452e)

## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #59 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

임시 저장 글을 만드는 API와 발행 API를 구현했습니다.
처음에 만든 게시글 작성 API에 사용한 서비스 메서드를 리팩토링 할까 생각도 해봤는데,
화면 설계서 상 임시 저장은 게시와는 다르게 제약 사항을 널럴하게 주는 것 같아 새로 메서드를 만들었습니다.

게시글 게시나 발행 때 태그가 겹치지 않도록 validateTagName 메서드를 추가했습니다.
테그를 바로 연결시키면 중복되는 태깅이 그대로 입력되어(tagging Id만 다르고 tag_id와 post_id가 동일한 2개의 필드가 생김) taggingRepository.deleteByPost를 사용해 태깅을 모두 지우고 새로 입력되도록 설정했습니다.

임시 저장글이 태그 검색 시 검색될 수 있는 가능성이 있어 추후에 TEMP인 게시글은 검색되지 않도록 리팩토링 해야 할 것 같습니다. 노션에 추가하겠습니다.