### PR TITLE
[FEAT}: 임시저장 게시글 목록 조회 API 구현

### DIFF
--- a/src/main/java/mvp/deplog/domain/post/application/PostService.java
+++ b/src/main/java/mvp/deplog/domain/post/application/PostService.java
@@ -11,6 +11,7 @@ import mvp.deplog.domain.post.domain.Stage;
 import mvp.deplog.domain.post.domain.repository.PostRepository;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
+import mvp.deplog.domain.post.dto.response.DraftListRes;
 import mvp.deplog.domain.post.dto.response.PostDetailsRes;
 import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.domain.post.exception.ResourceNotFoundException;
@@ -381,5 +382,22 @@ public class PostService {
                 .build();
 
         return SuccessResponse.of(createPostRes);
+    }
+
+    public SuccessResponse<List<DraftListRes>> getAllDraftPosts(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 id의 멤버를 찾을 수 없습니다: " + memberId));
+
+        List<Post> posts = postRepository.findByMemberAndStageOrderByCreatedDateDesc(member, Stage.TEMP);
+
+        List<DraftListRes> draftListRes = posts.stream()
+                .map(post -> DraftListRes.builder()
+                        .id(post.getId())
+                        .title(post.getTitle())
+                        .createdDate(post.getCreatedDate().toLocalDate())
+                        .build())
+                .collect(Collectors.toList());
+
+        return SuccessResponse.of(draftListRes);
     }
 }

--- a/src/main/java/mvp/deplog/domain/post/application/PostService.java
+++ b/src/main/java/mvp/deplog/domain/post/application/PostService.java
@@ -11,7 +11,7 @@ import mvp.deplog.domain.post.domain.Stage;
 import mvp.deplog.domain.post.domain.repository.PostRepository;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
-import mvp.deplog.domain.post.dto.response.DraftListRes;
+import mvp.deplog.domain.post.dto.response.TempListRes;
 import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.domain.post.exception.ResourceNotFoundException;
 import mvp.deplog.domain.post.exception.UnauthorizedException;
@@ -258,7 +258,7 @@ public class PostService {
     }
 
     @Transactional
-    public SuccessResponse<CreatePostRes> createDraftPost(Member member, CreatePostReq createPostReq) {
+    public SuccessResponse<CreatePostRes> createTempPost(Member member, CreatePostReq createPostReq) {
         String content = createPostReq.getContent();
         String previewContent = MarkdownUtil.extractPreviewContent(content);
         String previewImage = MarkdownUtil.extractPreviewImage(content);
@@ -298,7 +298,7 @@ public class PostService {
     }
 
     @Transactional
-    public SuccessResponse<CreatePostRes> publishDraftPost(Long memberId, Long postId, CreatePostReq createPostReq) {
+    public SuccessResponse<CreatePostRes> publishTempPost(Long memberId, Long postId, CreatePostReq createPostReq) {
         validateTagName(createPostReq.getTagNameList());
 
         Post post = postRepository.findById(postId)
@@ -338,20 +338,20 @@ public class PostService {
         return SuccessResponse.of(createPostRes);
     }
 
-    public SuccessResponse<List<DraftListRes>> getAllDraftPosts(Long memberId) {
+    public SuccessResponse<List<TempListRes>> getAllTempPosts(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 id의 멤버를 찾을 수 없습니다: " + memberId));
 
         List<Post> posts = postRepository.findByMemberAndStageOrderByCreatedDateDesc(member, Stage.TEMP);
 
-        List<DraftListRes> draftListRes = posts.stream()
-                .map(post -> DraftListRes.builder()
+        List<TempListRes> TempListRes = posts.stream()
+                .map(post -> mvp.deplog.domain.post.dto.response.TempListRes.builder()
                         .id(post.getId())
                         .title(post.getTitle())
                         .createdDate(post.getCreatedDate().toLocalDate())
                         .build())
                 .collect(Collectors.toList());
 
-        return SuccessResponse.of(draftListRes);
+        return SuccessResponse.of(TempListRes);
     }
 }

--- a/src/main/java/mvp/deplog/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/mvp/deplog/domain/post/domain/repository/PostRepository.java
@@ -1,7 +1,9 @@
 package mvp.deplog.domain.post.domain.repository;
 
+import mvp.deplog.domain.member.domain.Member;
 import mvp.deplog.domain.member.domain.Part;
 import mvp.deplog.domain.post.domain.Post;
+import mvp.deplog.domain.post.domain.Stage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +18,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByMemberPart(@Param("parts") List<Part> partGroup, Pageable pageable);
 
     Page<Post> findByTitleContainingOrContentContaining(String titleSearchWord, String contentSearchWord, Pageable pageable);
+
+    List<Post> findByMemberAndStageOrderByCreatedDateDesc(Member member, Stage stage);
 }

--- a/src/main/java/mvp/deplog/domain/post/dto/response/DraftListRes.java
+++ b/src/main/java/mvp/deplog/domain/post/dto/response/DraftListRes.java
@@ -1,5 +1,7 @@
 package mvp.deplog.domain.post.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,9 +11,13 @@ import java.time.LocalDate;
 @Builder
 public class DraftListRes {
 
+    @Schema(type = "Long", example = "1", description = "임시 저장 게시글 아이디입니다.")
     private Long id;
 
+    @Schema(type = "String", example = "임시 저장 게시글 제목", description= "임시 저장 게시글 제목입니다.")
     private String title;
 
+    @Schema(type = "LocalDate", example = "2024-08-05", description= "임시 저장 게시글 작성 날짜입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate createdDate;
 }

--- a/src/main/java/mvp/deplog/domain/post/dto/response/DraftListRes.java
+++ b/src/main/java/mvp/deplog/domain/post/dto/response/DraftListRes.java
@@ -1,0 +1,17 @@
+package mvp.deplog.domain.post.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class DraftListRes {
+
+    private Long id;
+
+    private String title;
+
+    private LocalDate createdDate;
+}

--- a/src/main/java/mvp/deplog/domain/post/dto/response/TempListRes.java
+++ b/src/main/java/mvp/deplog/domain/post/dto/response/TempListRes.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 
 @Data
 @Builder
-public class DraftListRes {
+public class TempListRes {
 
     @Schema(type = "Long", example = "1", description = "임시 저장 게시글 아이디입니다.")
     private Long id;

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -13,7 +13,7 @@ import mvp.deplog.domain.post.dto.response.AnonymousPostDetailRes;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
 import mvp.deplog.domain.post.dto.response.MemberPostDetailRes;
-import mvp.deplog.domain.post.dto.response.DraftListRes;
+import mvp.deplog.domain.post.dto.response.TempListRes;
 import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.PageResponse;
@@ -200,8 +200,8 @@ public interface PostApi {
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
             )
     })
-    @PostMapping("/drafts")
-    ResponseEntity<SuccessResponse<CreatePostRes>> createDraftPost(
+    @PostMapping("/temps")
+    ResponseEntity<SuccessResponse<CreatePostRes>> createTempPost(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
     );
@@ -218,7 +218,7 @@ public interface PostApi {
             )
     })
     @PutMapping("/publishing")
-    ResponseEntity<SuccessResponse<CreatePostRes>> publishDraftPost(
+    ResponseEntity<SuccessResponse<CreatePostRes>> publishTempPost(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "발행할 임시 저장 게시글의 아이디를 입력하세요.", required = true) @RequestParam(value = "postId") Long postId,
             @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
@@ -228,15 +228,15 @@ public interface PostApi {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200", description = "임시 저장 게시글 목록 조회 성공",
-                    content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = DraftListRes.class)))}
+                    content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = TempListRes.class)))}
             ),
             @ApiResponse(
                     responseCode = "400", description = "임시 저장 게시글 목록 조회 실패",
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
             )
     })
-    @GetMapping("/drafts")
-    ResponseEntity<SuccessResponse<List<DraftListRes>>> getAllDraftPosts(
+    @GetMapping("/temps")
+    ResponseEntity<SuccessResponse<List<TempListRes>>> getAllTempPosts(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails
     );
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import mvp.deplog.domain.member.domain.Part;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
+import mvp.deplog.domain.post.dto.response.DraftListRes;
 import mvp.deplog.domain.post.dto.response.PostDetailsRes;
 import mvp.deplog.domain.post.dto.response.PostListRes;
 import mvp.deplog.global.common.Message;
@@ -23,6 +24,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "Post API", description = "게시글 관련 API입니다.")
 public interface PostApi {
@@ -214,5 +217,10 @@ public interface PostApi {
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "발행할 임시 저장 게시글의 아이디를 입력하세요.", required = true) @RequestParam(value = "postId") Long postId,
             @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
+    );
+
+    @GetMapping("/drafts")
+    ResponseEntity<SuccessResponse<List<DraftListRes>>> getAllDraftPosts(
+            @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails
     );
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostApi.java
@@ -219,6 +219,17 @@ public interface PostApi {
             @Parameter(description = "Schemas의 CreatePostReq를 참고해주세요.", required = true) @RequestBody CreatePostReq createPostReq
     );
 
+    @Operation(summary = "임시 저장 게시글 목록 조회 API", description = "해당 아이디의 임시 저장 게시글 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "임시 저장 게시글 목록 조회 성공",
+                    content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = DraftListRes.class)))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "임시 저장 게시글 목록 조회 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}
+            )
+    })
     @GetMapping("/drafts")
     ResponseEntity<SuccessResponse<List<DraftListRes>>> getAllDraftPosts(
             @Parameter(description = "Access Token을 입력하세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
@@ -7,7 +7,7 @@ import mvp.deplog.domain.post.application.PostDetailServiceFactory;
 import mvp.deplog.domain.post.application.PostService;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
-import mvp.deplog.domain.post.dto.response.DraftListRes;
+import mvp.deplog.domain.post.dto.response.TempListRes;
 import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.PageResponse;
 import mvp.deplog.global.common.SuccessResponse;
@@ -90,25 +90,25 @@ public class PostController implements PostApi {
     }
 
     @Override
-    @PostMapping("/drafts")
-    public ResponseEntity<SuccessResponse<CreatePostRes>> createDraftPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    @PostMapping("/temps")
+    public ResponseEntity<SuccessResponse<CreatePostRes>> createTempPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                           @RequestBody CreatePostReq createPostReq) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(postService.createDraftPost(userDetails.getMember(), createPostReq));
+                .body(postService.createTempPost(userDetails.getMember(), createPostReq));
     }
 
     @Override
     @PutMapping("/publishing")
-    public ResponseEntity<SuccessResponse<CreatePostRes>> publishDraftPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    public ResponseEntity<SuccessResponse<CreatePostRes>> publishTempPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                            @RequestParam(value = "postId") Long postId,
                                                                            @RequestBody CreatePostReq createPostReq) {
-        return ResponseEntity.ok(postService.publishDraftPost(userDetails.getMember().getId(), postId, createPostReq));
+        return ResponseEntity.ok(postService.publishTempPost(userDetails.getMember().getId(), postId, createPostReq));
     }
 
     @Override
-    @GetMapping("/drafts")
-    public ResponseEntity<SuccessResponse<List<DraftListRes>>> getAllDraftPosts(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        return ResponseEntity.ok(postService.getAllDraftPosts(userDetails.getMember().getId()));
+    @GetMapping("/temps")
+    public ResponseEntity<SuccessResponse<List<TempListRes>>> getAllTempPosts(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        return ResponseEntity.ok(postService.getAllTempPosts(userDetails.getMember().getId()));
     }
 }

--- a/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
+++ b/src/main/java/mvp/deplog/domain/post/presentation/PostController.java
@@ -5,6 +5,7 @@ import mvp.deplog.domain.member.domain.Part;
 import mvp.deplog.domain.post.application.PostService;
 import mvp.deplog.domain.post.dto.response.CreatePostRes;
 import mvp.deplog.domain.post.dto.request.CreatePostReq;
+import mvp.deplog.domain.post.dto.response.DraftListRes;
 import mvp.deplog.domain.post.dto.response.PostDetailsRes;
 import mvp.deplog.global.common.Message;
 import mvp.deplog.global.common.PageResponse;
@@ -16,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -98,5 +101,11 @@ public class PostController implements PostApi {
                                                                            @RequestParam(value = "postId") Long postId,
                                                                            @RequestBody CreatePostReq createPostReq) {
         return ResponseEntity.ok(postService.publishDraftPost(userDetails.getMember().getId(), postId, createPostReq));
+    }
+
+    @Override
+    @GetMapping("/drafts")
+    public ResponseEntity<SuccessResponse<List<DraftListRes>>> getAllDraftPosts(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        return ResponseEntity.ok(postService.getAllDraftPosts(userDetails.getMember().getId()));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 임시저장 게시글 목록 조회 API

### 📷 스크린샷
화면 설계서 내 구현 내용
![스크린샷 2024-08-13 141650](https://github.com/user-attachments/assets/f369d395-4ad6-440f-99e5-214d19f0bdaf)

포스트맨 테스트 결과
조회 성공
![조회 성공](https://github.com/user-attachments/assets/d80b8b8c-3bdd-424a-9be8-81918cb8686a)
임시저장 게시글 없을 때 조회(다른 계정으로 테스트 - 계정에 따라 다르게 나타남)
![조회 성공 빈리스트](https://github.com/user-attachments/assets/07471db5-1a50-46be-b4bf-5ed55f66f284)
5번 게시글 발행 후 조회 성공
![DB 수정 후 조회 성공](https://github.com/user-attachments/assets/4f9232a5-93e3-4eb3-a70f-8c085872e7f7)

DB 수정 내용
Post 테이블
5번 게시글 발행 전
![DB 내용](https://github.com/user-attachments/assets/ed97f069-4ef9-4799-ae6c-a348fd481fe4)
5번 게시글 발행 후
![스크린샷 2024-08-13 141541](https://github.com/user-attachments/assets/3f9c1d20-ec77-4857-bbb6-85e3a1347db5)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #61 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

임시 저장 게시글 불러오기 목록입니다. 게시글 제목과 발행 날짜만 반환하면 돼서 새로운 Res DTO를 생성했습니다.
스크롤 방식이기 때문에 List 형식으로 구현했습니다.