### PR TITLE
[REFACTOR]: 댓글 조회 시 체크박스 여부에 따른 아바타 이미지 관련 로직 수정

### DIFF
--- a/src/main/java/mvp/deplog/domain/comment/application/CommentService.java
+++ b/src/main/java/mvp/deplog/domain/comment/application/CommentService.java
@@ -6,6 +6,8 @@ import mvp.deplog.domain.comment.domain.repository.CommentRepository;
 import mvp.deplog.domain.comment.dto.request.CreateCommentReq;
 import mvp.deplog.domain.comment.dto.response.CommentListRes;
 import mvp.deplog.domain.comment.dto.response.ReplyListRes;
+import mvp.deplog.domain.member.domain.Member;
+import mvp.deplog.domain.member.dto.Avatar;
 import mvp.deplog.domain.post.domain.Post;
 import mvp.deplog.domain.post.domain.repository.PostRepository;
 import mvp.deplog.global.common.Message;
@@ -32,10 +34,30 @@ public class CommentService {
         List<CommentListRes> commentDetails = new ArrayList<>();
 
         for(Comment comment : commentList) {
+            Avatar avatar;
+            if (comment.isUseNickname()) {
+                avatar = Avatar.builder()
+                        .avatarFace(null)
+                        .avatarBody(null)
+                        .avatarEyes(null)
+                        .avatarNose(null)
+                        .avatarMouth(null)
+                        .build();
+            } else {
+                Member member = comment.getMember();
+                avatar = Avatar.builder()
+                        .avatarFace(member.getAvatarFace())
+                        .avatarBody(member.getAvatarBody())
+                        .avatarEyes(member.getAvatarEyes())
+                        .avatarNose(member.getAvatarNose())
+                        .avatarMouth(member.getAvatarMouth())
+                        .build();
+            }
+
             if(comment.getParentComment() == null){
                 CommentListRes commentListRes = CommentListRes.builder()
                         .commentId(comment.getId())
-                        .avatarImage(comment.getAvatarImage()) // 아바타 이미지 url
+                        .avatar(avatar)
                         .nickname(comment.getNickname())
                         .createdDate(comment.getCreatedDate().toLocalDate())
                         .content(comment.getContent())
@@ -47,7 +69,7 @@ public class CommentService {
                 ReplyListRes replyListRes = ReplyListRes.builder()
                         .commentId(comment.getId())
                         .parentCommentId(comment.getParentComment().getId())
-                        .avatarImage(comment.getAvatarImage())     // 아바타 이미지 url
+                        .avatar(avatar)
                         .nickname(comment.getNickname())
                         .createdDate(comment.getCreatedDate().toLocalDate())
                         .content(comment.getContent())

--- a/src/main/java/mvp/deplog/domain/comment/application/CreateMemberCommentServiceImpl.java
+++ b/src/main/java/mvp/deplog/domain/comment/application/CreateMemberCommentServiceImpl.java
@@ -45,7 +45,7 @@ public class CreateMemberCommentServiceImpl implements CreateCommentService {
                 .member(member)
                 .content(createCommentReq.getContent())
                 .nickname(createCommentReq.getNickname())
-                .avatarImage(createCommentReq.getAvatarImage())
+                .useNickname(createCommentReq.isUseNicknameChecked())
                 .build();
 
         commentRepository.save(comment);

--- a/src/main/java/mvp/deplog/domain/comment/application/CreateMemberReplyServiceImpl.java
+++ b/src/main/java/mvp/deplog/domain/comment/application/CreateMemberReplyServiceImpl.java
@@ -48,7 +48,7 @@ public class CreateMemberReplyServiceImpl implements CreateCommentService {
                 .member(member)
                 .content(createCommentReq.getContent())
                 .nickname(createCommentReq.getNickname())
-                .avatarImage(createCommentReq.getAvatarImage())
+                .useNickname(createCommentReq.isUseNicknameChecked())
                 .build();
 
         commentRepository.save(reply);

--- a/src/main/java/mvp/deplog/domain/comment/domain/Comment.java
+++ b/src/main/java/mvp/deplog/domain/comment/domain/Comment.java
@@ -38,21 +38,21 @@ public class Comment extends BaseEntity {
     @Column(name = "nickname")
     private String nickname;
 
-    @Column(name = "avatar_image", columnDefinition = "TEXT")
-    private String avatarImage;
-
     @Column(name = "depth", columnDefinition = "INT", nullable = false)
     @Min(value = 1)
     private int depth;
 
+    @Column(name = "use_nickname", nullable = false)
+    private boolean useNickname;
+
     @Builder(builderMethodName = "memberCommentBuilder", builderClassName = "MemberCommentBuilder")
-    public Comment(Post post, Member member, String content, String nickname, String avatarImage) {
+    public Comment(Post post, Member member, String content, String nickname, boolean useNickname) {
         this.parentComment = null;
         this.post = post;
         this.member = member;
         this.content = content;
         this.nickname = nickname;
-        this.avatarImage = avatarImage;
+        this.useNickname = useNickname;
         this.depth = 1;
     }
 
@@ -63,18 +63,18 @@ public class Comment extends BaseEntity {
         this.member = null;
         this.content = content;
         this.nickname = nickname;
-        this.avatarImage = null;
+        this.useNickname = true;
         this.depth = 1;
     }
 
     @Builder(builderMethodName = "memberReplyBuilder", builderClassName = "MemberReplyBuilder")
-    public Comment(Comment parentComment, Post post, Member member, String content, String nickname, String avatarImage) {
+    public Comment(Comment parentComment, Post post, Member member, String content, String nickname, boolean useNickname) {
         this.parentComment = parentComment;
         this.post = post;
         this.member = member;
         this.content = content;
         this.nickname = nickname;
-        this.avatarImage = avatarImage;
+        this.useNickname = useNickname;
         this.depth = parentComment.getDepth() + 1;
     }
 
@@ -85,7 +85,7 @@ public class Comment extends BaseEntity {
         this.member = null;
         this.content = content;
         this.nickname = nickname;
-        this.avatarImage = null;
+        this.useNickname = true;
         this.depth = parentComment.getDepth() + 1;
     }
 }

--- a/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
@@ -18,6 +18,6 @@ public class CreateCommentReq {
     @Schema(type = "String", example = "닉네임", description = "닉네임입니다.")
     private String nickname;
 
-    @Schema(type = "String", example = "www.avatarImage.png", description = "댓글 아바타 이미지 Url입니다. 비회원 혹은 닉네임 사용 미체크 시 null입니다.")
-    private String avatarImage;
+    @Schema(type = "boolean", example = "true", description = "닉네임 사용 체크박스 체크 여부입니다. 회원이 체크 안한 경우, 비회원의 경우 모두 true입니다. 회원이 누른 경우만 falseh입니다.")
+    private boolean useNicknameChecked;
 }

--- a/src/main/java/mvp/deplog/domain/comment/dto/response/CommentListRes.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/response/CommentListRes.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
+import mvp.deplog.domain.member.dto.Avatar;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,8 +17,8 @@ public class CommentListRes {
     @Schema(type = "Long", example = "1", description = "댓글 아이디를 반환합니다.")
     private Long commentId;
 
-    @Schema(type = "String", example = "avatarImage.png", description = "댓글에 등록된 아바타 이미지를 반환합니다.")
-    private String avatarImage;
+    @Schema(type = "Avatar", description = "댓글 작성자의 아바타 이미지 객체입니다.")
+    private Avatar avatar;
 
     @Schema(type = "String", example = "댓글 작성자", description = "댓글 작성자의 닉네임을 반환합니다.")
     private String nickname;

--- a/src/main/java/mvp/deplog/domain/comment/dto/response/ReplyListRes.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/response/ReplyListRes.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
+import mvp.deplog.domain.member.dto.Avatar;
 
 import java.time.LocalDate;
 
@@ -11,22 +12,22 @@ import java.time.LocalDate;
 @Builder
 public class ReplyListRes {
 
-    @Schema(type = "Long", example = "1", description = "댓글 아이디를 반환합니다.")
+    @Schema(type = "Long", example = "1", description = "대댓글 아이디를 반환합니다.")
     private Long commentId;
 
     @Schema(type = "Long", example = "1", description = "부모 댓글의 아이디를 반환합니다.")
     private Long parentCommentId;
 
-    @Schema(type = "String", example = "avatarImage.png", description = "대댓글에 등록된 아바타 이미지를 반환합니다.")
-    private String avatarImage;
+    @Schema(type = "Avatar", description = "대댓글 작성자의 아바타 이미지 객체입니다.")
+    private Avatar avatar;
 
-    @Schema(type = "String", example = "댓글 작성자", description = "댓글 작성자의 닉네임을 반환합니다.")
+    @Schema(type = "String", example = "대댓글 작성자", description = "대댓글 작성자의 닉네임을 반환합니다.")
     private String nickname;
 
-    @Schema(type = "localDate", example = "2024-08-01", description = "댓글 작성 날짜를 반환합니다.")
+    @Schema(type = "localDate", example = "2024-08-01", description = "대댓글 작성 날짜를 반환합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate createdDate;
 
-    @Schema(type = "String", example = "**댓글 내용**", description = "댓글 내용을 반환합니다.")
+    @Schema(type = "String", example = "**대댓글 내용**", description = "대댓글 내용을 반환합니다.")
     private String content;
 }

--- a/src/main/resources/db/migration/V8__remove_comment_avatar.sql
+++ b/src/main/resources/db/migration/V8__remove_comment_avatar.sql
@@ -1,0 +1,5 @@
+ALTER TABLE comment
+    DROP COLUMN avatar_image;
+
+ALTER TABLE comment
+    ADD COLUMN use_nickname BOOLEAN NOT NULL;


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 댓글 조회 시 체크박스 여부에 따른 아바타 이미지 관련 로직 수정
- [x] comment - avatar_image 컬럼 삭제
- [x] comment - use_nickname 컬럼 추가

### 📷 스크린샷

![image](https://github.com/user-attachments/assets/5e3500fd-d40b-4c48-908d-8fa023269847)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #95 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

use_nickname 은 닉네임 사용할 것인지 체크박스 체크 여부입니다
기획 문의 결과 로그인 한 회원이 닉네임(회원 이름x)을 사용하여 댓글을 작성한 후 회원 탈퇴를 하면 삭제시키고 싶다고 합니다
귀찮고 좀 맘에 안들지만 그렇게 하기로 했고요, 아바타 이미지 5개를 comment에 저장하기 너무 많으니 체크박스 컬럼으로 구분합니다.
false면 회원이 본인 이름이랑 아바타 이미지 쓰겠다는 것이니까 member에서 가져오고, true면 avatar 5항목(얼굴, 몸통, 눈 ...) 모두 null입니다.

**CommentService에 댓글 목록 조회 코드에 if - else가 떡칠되어있고 진짜 개별로입니다. 근데, 지금 좀 이것저것 하긴 너무 귀찮고 오래 걸릴 것 같아서 저는 손 떼고 이 김에 재훈님이 한 번 구조적으로 생각해보시고 고쳐보면 좋을 것 같아요! 잘 돌아가는 것 같으니까 저희 할 일 다 하고 저것까지 재훈님이 하시는 걸로 합시다 ㅎㅎ**