### PR TITLE
[REFACTOR]: 댓글 관련 로직 수정

### DIFF
--- a/src/main/java/mvp/deplog/domain/comment/application/CreateMemberCommentServiceImpl.java
+++ b/src/main/java/mvp/deplog/domain/comment/application/CreateMemberCommentServiceImpl.java
@@ -56,12 +56,4 @@ public class CreateMemberCommentServiceImpl implements CreateCommentService {
 
         return SuccessResponse.of(message);
     }
-
-    private String commentNickname(Comment comment){
-        if(!comment.isUseNickname()) {
-            Member member = comment.getMember();
-            return member.getName();
-        }
-        return comment.getNickname();
-    }
 }

--- a/src/main/java/mvp/deplog/domain/comment/application/CreateMemberCommentServiceImpl.java
+++ b/src/main/java/mvp/deplog/domain/comment/application/CreateMemberCommentServiceImpl.java
@@ -56,4 +56,12 @@ public class CreateMemberCommentServiceImpl implements CreateCommentService {
 
         return SuccessResponse.of(message);
     }
+
+    private String commentNickname(Comment comment){
+        if(!comment.isUseNickname()) {
+            Member member = comment.getMember();
+            return member.getName();
+        }
+        return comment.getNickname();
+    }
 }

--- a/src/main/java/mvp/deplog/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/mvp/deplog/domain/comment/domain/repository/CommentRepository.java
@@ -14,5 +14,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 대댓글 목록 조회
     List<Comment> findByPostAndParentCommentIsNotNull(Post post);
 
-    void deleteByPost(Post post);
+    // 대댓글 삭제
+    void deleteByPostAndParentCommentIsNotNull(Post post);
+
+    // 댓글 삭제
+    void deleteByPostAndParentCommentIsNull(Post post);
 }

--- a/src/main/java/mvp/deplog/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/mvp/deplog/domain/comment/domain/repository/CommentRepository.java
@@ -8,7 +8,11 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    List<Comment> findByPost(Post post);
+    // 댓글 목록 조히
+    List<Comment> findByPostAndParentCommentIsNull(Post post);
+
+    // 대댓글 목록 조회
+    List<Comment> findByPostAndParentCommentIsNotNull(Post post);
 
     void deleteByPost(Post post);
 }

--- a/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
@@ -1,6 +1,7 @@
 package mvp.deplog.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
@@ -13,9 +14,11 @@ public class CreateCommentReq {
     private Long postId;
 
     @Schema(type = "String", example = "**댓글 내용**", description = "댓글 내용입니다.")
+    @NotBlank
     private String content;
 
     @Schema(type = "String", example = "닉네임", description = "닉네임입니다.")
+    @NotBlank
     private String nickname;
 
     @Schema(type = "boolean", example = "true", description = "닉네임 사용 체크박스 체크 여부입니다. 회원이 체크 안한 경우, 비회원의 경우 모두 true입니다. 회원이 누른 경우만 false입니다.")

--- a/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
@@ -18,6 +18,6 @@ public class CreateCommentReq {
     @Schema(type = "String", example = "닉네임", description = "닉네임입니다.")
     private String nickname;
 
-    @Schema(type = "boolean", example = "true", description = "닉네임 사용 체크박스 체크 여부입니다. 회원이 체크 안한 경우, 비회원의 경우 모두 true입니다. 회원이 누른 경우만 falseh입니다.")
+    @Schema(type = "boolean", example = "true", description = "닉네임 사용 체크박스 체크 여부입니다. 회원이 체크 안한 경우, 비회원의 경우 모두 true입니다. 회원이 누른 경우만 false입니다.")
     private boolean useNicknameChecked;
 }

--- a/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
@@ -18,7 +18,6 @@ public class CreateCommentReq {
     private String content;
 
     @Schema(type = "String", example = "닉네임", description = "닉네임입니다.")
-    @NotBlank
     private String nickname;
 
     @Schema(type = "boolean", example = "true", description = "닉네임 사용 체크박스 체크 여부입니다. 회원이 체크 안한 경우, 비회원의 경우 모두 true입니다. 회원이 누른 경우만 false입니다.")

--- a/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
+++ b/src/main/java/mvp/deplog/domain/comment/dto/request/CreateCommentReq.java
@@ -18,6 +18,7 @@ public class CreateCommentReq {
     private String content;
 
     @Schema(type = "String", example = "닉네임", description = "닉네임입니다.")
+    @NotBlank
     private String nickname;
 
     @Schema(type = "boolean", example = "true", description = "닉네임 사용 체크박스 체크 여부입니다. 회원이 체크 안한 경우, 비회원의 경우 모두 true입니다. 회원이 누른 경우만 false입니다.")

--- a/src/main/java/mvp/deplog/domain/comment/presentation/CommentApi.java
+++ b/src/main/java/mvp/deplog/domain/comment/presentation/CommentApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import mvp.deplog.domain.comment.dto.request.CreateCommentReq;
 import mvp.deplog.domain.comment.dto.response.CommentListRes;
 import mvp.deplog.global.common.Message;
@@ -40,7 +41,7 @@ public interface CommentApi {
     @PostMapping
     ResponseEntity<SuccessResponse<Message>> createComment(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Parameter(description = "Schemas의 CommentReq를 참고해주세요.", required = true) @RequestBody CreateCommentReq createCommentReq
+            @Parameter(description = "Schemas의 CommentReq를 참고해주세요.", required = true) @Valid @RequestBody CreateCommentReq createCommentReq
     );
 
     @Operation(summary = "댓글 목록 조회 API", description = "해당 게시글을 댓글 목록을 조회합니다.")

--- a/src/main/java/mvp/deplog/domain/comment/presentation/CommentController.java
+++ b/src/main/java/mvp/deplog/domain/comment/presentation/CommentController.java
@@ -1,5 +1,6 @@
 package mvp.deplog.domain.comment.presentation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mvp.deplog.domain.comment.application.CommentService;
 import mvp.deplog.domain.comment.application.CreateCommentService;
@@ -26,7 +27,8 @@ public class CommentController implements CommentApi {
 
     @Override
     @PostMapping
-    public ResponseEntity<SuccessResponse<Message>> createComment(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody CreateCommentReq createCommentReq) {
+    public ResponseEntity<SuccessResponse<Message>> createComment(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                  @Valid @RequestBody CreateCommentReq createCommentReq) {
         CreateCommentService createCommentService = createCommentServiceFactory.find(userDetails, createCommentReq.getParentCommentId());
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/mvp/deplog/domain/post/application/PostService.java
+++ b/src/main/java/mvp/deplog/domain/post/application/PostService.java
@@ -222,8 +222,11 @@ public class PostService {
             throw new UnauthorizedException("본인이 작성한 게시글이 아니므로 삭제할 수 없습니다.");
         }
 
+        // 게시글 내 대댓글 삭제
+        commentRepository.deleteByPostAndParentCommentIsNotNull(post);
+
         // 게시글 내 댓글 삭제
-        commentRepository.deleteByPost(post);
+        commentRepository.deleteByPostAndParentCommentIsNull(post);
 
         // 게시글 내 태그 삭제
         taggingRepository.deleteByPost(post);


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요

- [x] 댓글 목록 조회 로직 리팩토링
- [x] 닉네임 사용 여부에 따른 로직 추가
- [x] 아바타 이미지 관련 로직 추가
- [x] 게시글 삭제 시 대댓글 먼저 삭제되도록 수정

### 📷 스크린샷
![스크린샷 2024-08-18 032141](https://github.com/user-attachments/assets/7e399bab-97b7-40de-9fda-bf8374d5bc04)
![스크린샷 2024-08-18 032155](https://github.com/user-attachments/assets/51f893f1-4282-4385-9b72-62da99ccd39b)
![스크린샷 2024-08-18 032203](https://github.com/user-attachments/assets/ede29af6-fc8a-45fe-af55-1ca9812e2749)


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #104 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

댓글 관련 로직 수정 완료했습니다.
1. if~else문을 for문과 자체 메소드로 구현했습니다.
2. 2번 호출해야 하지만 안정성 문제를 위해 댓글 먼저 호출하고 대댓글을 나중에 호출하도록 수정했습니다.
3. 원래는 service에 useNickname에 따라 이름/닉네임이 뜨도록 구현했으나 db에는 useNickname이 false면 이름이 저장되어 있을것이기 때문에 comment db에서 가져오는 것으로 결정했습니다.
4. 게시글 삭제 시 대댓글이 먼저 삭제되고 다음에 댓글이 삭제되도록 구현했습니다.